### PR TITLE
Fix composer example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Imagine your `composer.json` looks like this:
     "require" : {
         "mouf/classname-mapper": "~1.0"
     },
-	"autoload" : {
-		"psr-4" : {
-			"Acme\\" : "src/"
-		}
-	}
+    "autoload" : {
+        "psr-4" : {
+            "Acme\\" : "src/"
+        }
+    }
 }
 ```
 


### PR DESCRIPTION
Part of the `composer.json` example used tabs instead of spaces