### PR TITLE
Load from the composer autoload

### DIFF
--- a/src/ClassNameMapper.php
+++ b/src/ClassNameMapper.php
@@ -91,6 +91,23 @@ class ClassNameMapper
     }
 
     /**
+     * @param  string|null $composerAutoloadPath
+     * @return ClassNameMapper
+     */
+    public static function createFromComposerAutoload($composerAutoloadPath = null)
+    {
+        $classNameMapper = new ClassNameMapper();
+
+        if ($composerAutoloadPath === null) {
+            $composerAutoloadPath = __DIR__ . '/../../../autoload.php';
+        }
+
+        $classNameMapper->loadComposerAutoload($composerAutoloadPath);
+
+        return $classNameMapper;
+    }
+
+    /**
      *
      * @param string $composerJsonPath Path to the composer file
      * @param string $rootPath Root path of the project (or null)
@@ -121,6 +138,7 @@ class ClassNameMapper
 
         if (isset($composer["autoload"]["psr-4"])) {
             $psr4 = $composer["autoload"]["psr-4"];
+
             foreach ($psr4 as $namespace => $paths) {
                 if ($relativePath != null) {
                     if (!is_array($paths)) {
@@ -163,6 +181,27 @@ class ClassNameMapper
                     }
                     $this->registerPsr4Namespace($namespace, $paths);
                 }
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param  string $composerAutoloadPath
+     * @return self
+     */
+    public function loadComposerAutoload($composerAutoloadPath)
+    {
+        if (file_exists($composerAutoloadPath)) {
+            $loader = require $composerAutoloadPath;
+
+            foreach ($loader->getPrefixes() as $namespace => $paths) {
+                $this->registerPsr0Namespace($namespace, $paths);
+            }
+
+            foreach ($loader->getPrefixesPsr4() as $namespace => $paths) {
+                $this->registerPsr4Namespace($namespace, $paths);
             }
         }
 

--- a/tests/ClassNameMapperTest.php
+++ b/tests/ClassNameMapperTest.php
@@ -14,6 +14,11 @@ class ClassNameMapperTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([ 'src/Foo/Bar.php', 'src2/Bar.php' ], $possibleFiles);
 
+        //From autoloader instead of composer.json
+        $mapper = ClassNameMapper::createFromComposerAutoload(__DIR__ . '/../vendor/autoload.php');
+        $possibleFiles = $mapper->getPossibleFileNames('Mouf\\Composer\\ClassNameMapper');
+
+        $this->assertEquals([ realpath(__DIR__ . '/../vendor/composer/') . '/../../src/ClassNameMapper.php', realpath(__DIR__ . '/../vendor/composer/') . '/../../tests/ClassNameMapper.php' ], $possibleFiles);
     }
 
     public function testUseAutoloadDev() {

--- a/tests/ClassNameMapperTest.php
+++ b/tests/ClassNameMapperTest.php
@@ -15,10 +15,14 @@ class ClassNameMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([ 'src/Foo/Bar.php', 'src2/Bar.php' ], $possibleFiles);
 
         //From autoloader instead of composer.json
-        $mapper = ClassNameMapper::createFromComposerAutoload(__DIR__ . '/../vendor/autoload.php');
+        $mapper = ClassNameMapper::createFromComposerAutoload(__DIR__ . '/Fixtures/test_autoload.php');
         $possibleFiles = $mapper->getPossibleFileNames('Mouf\\Composer\\ClassNameMapper');
 
-        $this->assertEquals([ realpath(__DIR__ . '/../vendor/composer/') . '/../../src/ClassNameMapper.php', realpath(__DIR__ . '/../vendor/composer/') . '/../../tests/ClassNameMapper.php' ], $possibleFiles);
+        $this->assertEquals([
+                'src/ClassNameMapper.php'
+            ],
+            $possibleFiles
+        );
     }
 
     public function testUseAutoloadDev() {

--- a/tests/Fixtures/test_autoload.php
+++ b/tests/Fixtures/test_autoload.php
@@ -1,0 +1,8 @@
+<?php
+
+use Composer\Autoload\ClassLoader;
+
+$classLoader = new ClassLoader();
+$classLoader->setPsr4('Mouf\\Composer\\', ['src/']);
+
+return $classLoader;


### PR DESCRIPTION
I created an extra method `createFromComposerAutoload` to load the ClassNameMapper with data of the composer autoloader.

If you use the `createFromComposerFile` method you only get the specific information of your custom added autoloading. With the new loading option you can also get information of namespaces in vendor packages.

I hope you like it.